### PR TITLE
Hotfix/hashed filenames

### DIFF
--- a/turbo_sort.py
+++ b/turbo_sort.py
@@ -21,7 +21,6 @@ import os
 import re
 import shutil
 import string
-import datetime
 
 # Edit these variables to your liking, make sure to use \\ for backslash or / for forward slash 
 undated_fs = "%t\\Season %s\\%t S%0s E%0e"
@@ -232,9 +231,7 @@ def populate_fields(filepath):
 
     # If the filename is encoded like a hashname containing hexadecimal, use the directory name instead
     if re.match(hexaPattern, filename):
-        # To avoid file erasing, we put the file datetime in the name
-        fileatime = datetime.datetime.fromtimestamp(os.path.getatime(filepath))
-        filename = os.path.basename(os.path.dirname(filepath)) + "_" + fileatime.strftime("%Y%m%d_%H%M%S")
+        filename = os.path.basename(os.path.dirname(filepath))
 
     # remove scenegroup from scenegroup-movie.title.*
     hyph = filename.find('-')

--- a/turbo_sort.py
+++ b/turbo_sort.py
@@ -63,7 +63,8 @@ quality_attributes = ["1080p", "720p", "480p", "xvid", "1080i", "1080"]
 ignore_attributes = ["hdtv", "dts"]
 consolesize = 80
 
-hexaPattern = re.compile('[0-9a-fA-F]+')
+# To avoid problem of false positive hexa, start matching at 6 characters
+hexaPattern = re.compile('[0-9a-fA-F]{6}')
 
 #tvdest     = "D:\\Documents\\Scripts\\Script test files\\tvdest"
 #moviedest  = "D:\\Documents\\Scripts\\Script test files\\moviedest"

--- a/turbo_sort.py
+++ b/turbo_sort.py
@@ -63,7 +63,8 @@ quality_attributes = ["1080p", "720p", "480p", "xvid", "1080i", "1080"]
 ignore_attributes = ["hdtv", "dts"]
 consolesize = 80
 
-hexaPattern = re.compile('[0-9a-fA-F]+')
+# To avoid problem of false positive hexa, start matching at 32 characters
+hexaPattern = re.compile('[0-9a-fA-F]{32}')
 
 #tvdest     = "D:\\Documents\\Scripts\\Script test files\\tvdest"
 #moviedest  = "D:\\Documents\\Scripts\\Script test files\\moviedest"

--- a/turbo_sort.py
+++ b/turbo_sort.py
@@ -64,8 +64,7 @@ quality_attributes = ["1080p", "720p", "480p", "xvid", "1080i", "1080"]
 ignore_attributes = ["hdtv", "dts"]
 consolesize = 80
 
-# To avoid problem of false positive hexa, start matching at 6 characters
-hexaPattern = re.compile('[0-9a-fA-F]{6}')
+hexaPattern = re.compile('[0-9a-fA-F]+')
 
 #tvdest     = "D:\\Documents\\Scripts\\Script test files\\tvdest"
 #moviedest  = "D:\\Documents\\Scripts\\Script test files\\moviedest"

--- a/turbo_sort.py
+++ b/turbo_sort.py
@@ -21,6 +21,7 @@ import os
 import re
 import shutil
 import string
+import datetime
 
 # Edit these variables to your liking, make sure to use \\ for backslash or / for forward slash 
 undated_fs = "%t\\Season %s\\%t S%0s E%0e"
@@ -232,7 +233,9 @@ def populate_fields(filepath):
 
     # If the filename is encoded like a hashname containing hexadecimal, use the directory name instead
     if re.match(hexaPattern, filename):
-        filename = os.path.basename(os.path.dirname(filepath))
+        # To avoid file erasing, we put the file datetime in the name
+        fileatime = datetime.datetime.fromtimestamp(os.path.getatime(filepath))
+        filename = os.path.basename(os.path.dirname(filepath)) + "_" + fileatime.strftime("%Y%m%d_%H%M%S")
 
     # remove scenegroup from scenegroup-movie.title.*
     hyph = filename.find('-')


### PR DESCRIPTION
Hi,
Since i have upgraded to 2.3, hi have problems with the hashed filenames detection. In some case, when the first characters match with the pattern, the filename is replaced by the folder name.
In my case, this is problematic, because, all movies are in the same directory. And if multiple file match this pattern, the last file erase all others.

This matched: cXxx.xxxxx.xxxxx.xxxxx.xxx
This not matched: gcXxx.xxxxx.xxxxx.xxxxx.xxx

Because in my case i have never seen a file with an hexa pattern in name, i suppose the 6 characters would be good compromise.

Thank you in advance, if you want to merge this with the master.
Michael F.